### PR TITLE
Do not fail if already installed or running

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,3 +29,4 @@
     remoteip: '{{ zabbix_server_ip }}'
     state: present
     enabled: yes
+

--- a/tasks/version3.yml
+++ b/tasks/version3.yml
@@ -4,6 +4,11 @@
     url: '{{ zabbix_agent_url_v3 }}'
     dest: C:\Zabbix\zabbix_agent.zip
 
+- name: V3 Stop zabbix-agent for arch {{ win_arch_fact }}
+  win_command: CMD /C 'C:\Zabbix\bin\win{{ win_arch_fact }}\zabbix_agentd.exe --config C:\Zabbix\conf\zabbix_agentd.win.conf --stop'
+  register: fail_me
+  failed_when: "fail_me.rc != 0 and fail_me.rc != 1"
+
 - name: V3 Unzip zabbix-agent.zip
   win_unzip:
     src: C:\Zabbix\zabbix_agent.zip
@@ -22,6 +27,10 @@
 
 - name: V3 Install zabbix-agent for arch {{ win_arch_fact }}
   win_command: CMD /C 'C:\Zabbix\bin\win{{ win_arch_fact }}\zabbix_agentd.exe --config C:\Zabbix\conf\zabbix_agentd.win.conf --install'
+  register: fail_me
+  failed_when: "fail_me.rc != 0 and fail_me.rc != 1"
 
 - name: V3 Start zabbix-agent for arch {{ win_arch_fact }}
   win_command: CMD /C 'C:\Zabbix\bin\win{{ win_arch_fact }}\zabbix_agentd.exe --config C:\Zabbix\conf\zabbix_agentd.win.conf --start'
+  register: fail_me
+  failed_when: "fail_me.rc != 0 and fail_me.rc != 1"

--- a/tasks/version4.yml
+++ b/tasks/version4.yml
@@ -3,13 +3,13 @@
   win_get_url:
     url: '{{ zabbix_agent_url_v4_i386 }}'
     dest: C:\Zabbix\zabbix_agent.zip
-  when: (win_arch_fact == '32')
+  when: (win_arch_fact == 32)
 
 - name: V4 Download zabbix-agent.zip for amd64
   win_get_url:
     url: '{{ zabbix_agent_url_v4_amd64 }}'
     dest: C:\Zabbix\zabbix_agent.zip
-  when: (win_arch_fact == '64')
+  when: (win_arch_fact == 64)
 
 - name: V4 Unzip zabbix-agent.zip
   win_unzip:

--- a/tasks/version4.yml
+++ b/tasks/version4.yml
@@ -28,7 +28,12 @@
     dest: 'C:\Zabbix\conf\zabbix_agentd.win.conf'
 
 - name: V4 Install zabbix-agent for arch {{ win_arch_fact }}
-  win_command: CMD /C 'C:\Zabbix\bin\zabbix_agentd.exe --config C:\Zabbix\conf\zabbix_agentd.win.conf --install'
+  win_command: CMD /C "C:\Zabbix\bin\zabbix_agentd.exe --config C:\Zabbix\conf\zabbix_agentd.win.conf --install"
+  register: fail_me
+  failed_when: "fail_me.rc != 0 and fail_me.rc != 1"
 
 - name: V4 Start zabbix-agent for arch {{ win_arch_fact }}
-  win_command: CMD /C 'C:\Zabbix\bin\zabbix_agentd.exe --config C:\Zabbix\conf\zabbix_agentd.win.conf --start'
+  win_command: CMD /C "C:\Zabbix\bin\zabbix_agentd.exe --config C:\Zabbix\conf\zabbix_agentd.win.conf --start"
+  register: fail_me
+  failed_when: "fail_me.rc != 0 and fail_me.rc != 1"
+


### PR DESCRIPTION
Do not fail when if zabbix agent is already installed or running and the role is run again.
Fix win_arch_fact - comparison was not working on Ansible 2.7.6 Ubuntu 18.04